### PR TITLE
fix: correct bed_out text

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -73,7 +73,7 @@
         "lie_bed": "[E] - To lay in bed",
         "bed": "Lay in bed",
         "put_bed": "Place citizen in bed",
-        "bed_out": "[E] - To get out of bed..",
+        "bed_out": "[E] - To get out of bed.",
         "alert": "Alert!"
     },
     "progress": {


### PR DESCRIPTION
## Summary
- fix spelling in bed_out text prompt

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a151ec6a9c8322909fe94b94ddc74c