### PR TITLE
refactor: remove duplicate triggerEventOnEmsPlayer

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -270,12 +270,3 @@ RegisterNetEvent("QBCore:Everfall:EMSClockOut", function(_source)
     if not player then return end
     TriggerEvent('QBCore:Everfall:EMS:Timeclock', player, false)
 end)
-
-local function triggerEventOnEmsPlayer(src, event)
-    local player = exports.qbx_core:GetPlayer(src)
-    if player.PlayerData.job.type ~= 'ems' then
-        exports.qbx_core:Notify(src, locale('error.not_ems'), 'error')  -- ✅ server->client notify
-        return
-    end
-    TriggerClientEvent(event, src)
-end


### PR DESCRIPTION
## Summary
- remove duplicate `triggerEventOnEmsPlayer` definition

## Testing
- `luac -p server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a151ed78a483229114d60b3c2588ea